### PR TITLE
chore(deps): enable server-side automerge for github-actions bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,10 @@ updates:
   # requires active maintenance. Dependabot helps stay current.
   - package-ecosystem: "github-actions"
     directory: "/"
+    allow:
+      - dependency-type: "direct"
+    automerge:
+      - dependency-type: "direct"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Adds `allow` + `automerge` to the github-actions Dependabot block so GitHub auto-merges safe action bumps natively (no external watcher needed).